### PR TITLE
This pull request resolves #91

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -2,7 +2,7 @@
 * @Author: justinwebb
 * @Date:   2015-05-04 15:12:58
 * @Last Modified by:   nimi
-* @Last Modified time: 2015-05-11 14:07:33
+* @Last Modified time: 2015-05-11 15:37:30
 */
 'use strict';
 var config = require('./server-config');
@@ -24,14 +24,16 @@ models.sequelize.sync()
   server.listen(config.port, function () {
     console.log('Express server listening on port %d', config.port);
     open( 'http://localhost:' + config.port, function (err) {
+      //when deploying to heroku, this will fail because heroku does not have a browser. Since we don't want this to stop
+      //our app from running, console log the error and move on
       if (err) {
-        throw err;
+        console.error(err); 
       } else {
           console.log('App server browser tab is open...');
       }
     });
   });
-})
+});
 
 // Configure our server with middleware for routing
 require('./routes/middleware.js')(app, express, passport);


### PR DESCRIPTION
This change will stop the app from crashing when open fails. Open will fail when deploying because Heroku does not have a browser (expected). Instead of throwing the error, the app will now console.error it
